### PR TITLE
feat: Support globbing for plugins

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 projectsophon
+Copyright (c) 2021 Blaine Bublitz <blaine.bublitz@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Start a Dark Forest plugin development server.
 Options:
   --help     Show help                                                 [boolean]
   --version  Show version number                                       [boolean]
-  --dir      The directory where plugins exist     [string] [default: "plugins"]
-  --ext      Extensions to process              [array] [default: [".js",".ts"]]
+  --dir      The directory to load     [deprecated: use --glob instead] [string]
+  --ext      Extensions to process      [deprecated: use --glob instead] [array]
+  --glob     Glob for finding plugins   [array] [default: ["plugins/*.(js|ts)"]]
 ```
 
 And then run the server:
@@ -52,18 +53,14 @@ The easiest way to load plugins while developing would be to use something like 
 
 ```js
 // This maps to ./plugins/PluginTemplate.js or ./plugins/PluginTemplate.ts by default
-import Plugin from "http://127.0.0.1:2222/PluginTemplate.js"
-
-export default Plugin;
+export { default } from "http://127.0.0.1:2222/PluginTemplate.js";
 ```
 
 However, Dark Forest plugins are cached, so you'd need to do some sort of cache busting each time you make a change. Luckily, we've taken care of that for you! To get free cache busting, you can add `?dev` to the end of your plugin URL.
 
 ```js
 // Notice the ?dev
-import Plugin from "http://127.0.0.1:2222/PluginTemplate.js?dev"
-
-export default Plugin;
+export { default } from "http://127.0.0.1:2222/PluginTemplate.js?dev";
 ```
 
 Doing the above will proxy your plugin through a cache busting plugin!
@@ -101,7 +98,6 @@ docker stop plugin_server
 ### Security notes for docker containers
 
 Docker is working on another layer meaning your internet connection from docker containers is bridged through your network interface by default. Starting this container with default configuration using commands from above opens port to this docker container to any incoming IP subnet existing (bind 0.0.0.0). Default system firewall configuration will not prevent access from outside world if your router does not block ports by default. KEEP THIS IN MIND. Storing vulnerable data inside container is not recommended with this configuration. You should edit docker network of `plugin_server` to make it harden. The easiest way is to set flag `--internal` for specific docker network, to prevent access from other computers.
-
 
 ## License
 

--- a/cli.js
+++ b/cli.js
@@ -12,14 +12,19 @@ const parser = yargs()
     (yargs) => {
       return yargs.options({
         dir: {
-          desc: "The directory where plugins exist",
+          desc: "The directory to load",
           type: "string",
-          default: "plugins",
+          deprecated: "use --glob instead",
         },
         ext: {
           desc: "Extensions to process",
           type: "array",
-          default: [".js", ".ts"],
+          deprecated: "use --glob instead",
+        },
+        glob: {
+          desc: "Glob for finding plugins",
+          type: "array",
+          default: ["plugins/*.(js|ts)"],
         },
       });
     },

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "chalk": "^4.1.1",
     "esbuild": "^0.12.1",
+    "fast-glob": "^3.2.6",
     "get-port": "^5.1.1",
     "yargs": "^17.0.1"
   },


### PR DESCRIPTION
This also deprecates the `dir` and `ext` flags because globs are just better.

Closes #6 because that wasn't updated to use globs.