### PR TITLE
Preact overrides

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -24,7 +24,7 @@ const parser = yargs()
         glob: {
           desc: "Glob for finding plugins",
           type: "array",
-          default: ["plugins/*.(js|ts)"],
+          default: ["plugins/*.(js|jsx|ts|tsx)"],
         },
       });
     },

--- a/cli.js
+++ b/cli.js
@@ -26,6 +26,11 @@ const parser = yargs()
           type: "array",
           default: ["plugins/*.(js|jsx|ts|tsx)"],
         },
+        preact: {
+          desc: "Enabled custom preact support",
+          type: "boolean",
+          default: false,
+        },
       });
     },
     start

--- a/server.js
+++ b/server.js
@@ -34,15 +34,31 @@ export async function start({ dir, ext, glob }) {
     printLocation = glob.map((g) => underline(path.join(process.cwd(), g))).join(", ");
   }
 
+  // Custom resolver that externalizes http:// and https:// imports
+  const httpExternalResolver = {
+    name: "http-external",
+    setup(build) {
+      // Mark all paths starting with "http://" or "https://" as external
+      build.onResolve({ filter: /^https?:\/\// }, (args) => {
+        return { path: args.path, external: true };
+      });
+    },
+  };
+
   const esbuildServeConfig = {
     port: esbuildPort,
   };
+
+  const jsxConfig = {};
+  const plugins = [httpExternalResolver];
 
   const esbuildConfig = {
     entryPoints: entryPoints,
     bundle: true,
     format: "esm",
     target: ["es2020"],
+    plugins,
+    ...jsxConfig,
   };
 
   const { host, port } = await esbuild.serve(esbuildServeConfig, esbuildConfig);


### PR DESCRIPTION
This adds support for Preact JSX behind a flag. This is needed to wire up Apollo (which hard codes React throughout) in p2e

You'll need to have this branch checked out next to my p2e PR coming up.