### PR TITLE
Update cli.js

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -24,7 +24,7 @@ const parser = yargs()
         glob: {
           desc: "Glob for finding plugins",
           type: "array",
-          default: ["**/*.(js|jsx|ts|tsx)"],
+          default: ["(plugins|content)/**/*.(js|jsx|ts|tsx)"],
         },
         preact: {
           desc: "Enabled custom preact support",

--- a/cli.js
+++ b/cli.js
@@ -24,7 +24,7 @@ const parser = yargs()
         glob: {
           desc: "Glob for finding plugins",
           type: "array",
-          default: ["plugins/*.(js|jsx|ts|tsx)"],
+          default: ["**/*.(js|jsx|ts|tsx)"],
         },
         preact: {
           desc: "Enabled custom preact support",


### PR DESCRIPTION
change glob to allow nesting of directories. Right now, this will only search for *.js files in the plugins root (which doesn't match the structure of the darkforest-eth/plugins repo anyway). With `"**/*.(js|jsx|ts|tsx)"` as my default, I can run `df-plugin-server` in `plugins/content` and get a nested structure.